### PR TITLE
chore: add ResponseInterceptor benchmark suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,10 @@
       "<rootDir>/sample/",
       "<rootDir>/lib/"
     ],
+    "moduleDirectories": [
+      "node_modules",
+      "<rootDir>"
+    ],
     "moduleNameMapper": {
       "@hodfords/nestjs-response(|/.*)$": "<rootDir>/lib/nestjs-response/sample/$1"
     }

--- a/sample/bench/README.md
+++ b/sample/bench/README.md
@@ -1,0 +1,91 @@
+# ResponseInterceptor Benchmarks
+
+Benchmarks for measuring the runtime cost of the response interceptor on deeply nested payloads. Useful for evaluating whether `validateSync` + `@ValidateNested` recursion is a bottleneck for your endpoints and for guiding per-endpoint validation decisions.
+
+## Layout
+
+```
+sample/bench/
+├── responses/
+│   ├── board.responses.ts   # deeply nested response classes (groups → columns → items → task → attachments)
+│   └── board.fixtures.ts    # data generators
+├── response-bench.spec.ts   # synthetic plainToInstance + validateSync timing + breakdown
+├── bench.controller.ts      # HTTP endpoint returning fixture data
+├── bench.module.ts          # Nest module wiring the bench controller + ResponseModule
+└── bench-http.spec.ts       # end-to-end HTTP timing via supertest
+```
+
+## Running
+
+Install deps once:
+
+```bash
+npm install
+```
+
+### Synthetic benchmark (no HTTP overhead)
+
+Runs `plainToInstance` + `validateSync` directly and reports mean / p50 / p95 across iterations.
+
+```bash
+npx jest sample/bench/response-bench.spec.ts
+```
+
+Contains two tests:
+
+- **`runs benchmark`** — compares the full stock path (`plainToInstance` + `validateSync({whitelist, stopAtFirstError})` + `excludeByKeys`) against a fast path (`plainToInstance` only) across small (50 tasks) and medium (250 tasks) payloads.
+- **`breakdown`** — isolates the cost of each individual step so you can see exactly where time goes.
+
+### HTTP benchmark
+
+Bootstraps a real Nest app via `@nestjs/testing`, hits `GET /bench/group-boards` through `supertest`, and reports latency end-to-end.
+
+```bash
+npx jest sample/bench/bench-http.spec.ts
+```
+
+Default payload is 5 groups × 5 columns × 40 tasks = 1000 tasks. Adjust in `bench-http.spec.ts`:
+
+```ts
+const query = { groups: '5', cols: '5', tasks: '40' };
+```
+
+## Interpreting the breakdown
+
+Sample output on a ~1085-node payload (5 groups × 5 columns × 10 tasks):
+
+```
+[1] plainToInstance only                             mean=41.24ms
+[2] validateSync({}) recursive via @ValidateNested   mean=12.19ms
+[3] validateSync({whitelist:true}) recursive         mean=15.08ms
+[4] validateSync({whitelist,stopAtFirstError}) STOCK mean=12.99ms
+[5] validateSync({whitelist:true}) NO nested         mean= 0.03ms
+[6] excludeByKeys (recursive prop strip)             mean= 1.31ms
+```
+
+| Line | What it measures |
+|------|------------------|
+| `[1]` | Shared cost of building class instances from raw data — both the stock and fast paths pay this. |
+| `[4]` | Total `validateSync` cost as the stock interceptor calls it. |
+| `[4] - [1]` | Total overhead the stock interceptor adds beyond a fast path. |
+| `[5]` | `validateSync` cost when `@ValidateNested` is **not** present — root-level fields only. |
+| `[4] - [5]` | Cost of `@ValidateNested` recursing into every nested instance. Usually the dominant cost on deeply nested payloads. |
+| `[3] - [2]` | Cost of whitelist stripping in isolation. |
+| `[6]` | Cost of the `excludedKeys` recursive prop strip. |
+
+The big lever in `[5]` is removing `@ValidateNested` from response classes — this collapses validation cost by orders of magnitude on deeply nested payloads, at the price of giving up nested type-level validation in production.
+
+## Tweaking payload size
+
+In `response-bench.spec.ts`:
+
+```ts
+const smallBoards  = makeBoardColumns(5, 10);   // 5 cols × 10 tasks
+const mediumBoards = makeBoardColumns(5, 50);   // 5 cols × 50 tasks
+const smallGroup   = makeGroupBoardColumns(5, 5, 5);
+const mediumGroup  = makeGroupBoardColumns(5, 5, 10);
+```
+
+`makeBoardColumns(columnCount, taskPerColumn)` and `makeGroupBoardColumns(groupCount, columnPerGroup, taskPerColumn)` accept any sizes — scale them up to match your real-world worst case.
+
+Iteration counts and warmups are arguments to `bench(label, fn, iterations, warmup)`. Increase both for tighter measurements on small payloads; lower them for very large payloads to keep total runtime sane.

--- a/sample/bench/bench-http.spec.ts
+++ b/sample/bench/bench-http.spec.ts
@@ -1,0 +1,53 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { BenchModule } from './bench.module';
+
+describe('Response interceptor HTTP benchmark', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [BenchModule]
+        }).compile();
+
+        app = moduleRef.createNestApplication();
+        await app.init();
+    });
+
+    afterAll(async () => {
+        await app.close();
+    });
+
+    it('benchmarks GET /bench/group-boards (5 groups x 5 cols x 40 tasks = 1000 tasks)', async () => {
+        const WARMUP = 3;
+        const MEASURE = 10;
+        const query = { groups: '5', cols: '5', tasks: '40' };
+
+        const server = app.getHttpServer();
+        const call = (): Promise<unknown> =>
+            request(server).get('/bench/group-boards').query(query).expect(200);
+
+        for (let i = 0; i < WARMUP; i++) {
+            await call();
+        }
+
+        const samples: number[] = [];
+        for (let i = 0; i < MEASURE; i++) {
+            const start = process.hrtime.bigint();
+            await call();
+            const end = process.hrtime.bigint();
+            samples.push(Number(end - start) / 1_000_000);
+        }
+        samples.sort((a, b) => a - b);
+
+        const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+        const p50 = samples[Math.floor(samples.length * 0.5)];
+        const p95 = samples[Math.floor(samples.length * 0.95)];
+
+        process.stdout.write(
+            `\nHTTP bench /bench/group-boards  (1000 tasks, 2000 attachments)\n` +
+                `  samples=${MEASURE}  mean=${mean.toFixed(1)}ms  p50=${p50.toFixed(1)}ms  p95=${p95.toFixed(1)}ms\n\n`
+        );
+    }, 600000);
+});

--- a/sample/bench/bench.controller.ts
+++ b/sample/bench/bench.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { ResponseModel, UseResponseInterceptor } from 'lib';
+import { GroupBoardColumnResponse } from './responses/board.responses';
+import { makeGroupBoardColumns } from './responses/board.fixtures';
+
+@Controller('bench')
+@UseResponseInterceptor()
+export class BenchController {
+    private cache: Map<string, unknown[]> = new Map();
+
+    @Get('group-boards')
+    @ResponseModel(GroupBoardColumnResponse, true)
+    @HttpCode(HttpStatus.OK)
+    getGroupBoards(
+        @Query('groups') groupsRaw: string,
+        @Query('cols') colsRaw: string,
+        @Query('tasks') tasksRaw: string
+    ): unknown[] {
+        const groups = Number(groupsRaw) || 5;
+        const cols = Number(colsRaw) || 5;
+        const tasks = Number(tasksRaw) || 10;
+        const key = `${groups}-${cols}-${tasks}`;
+
+        let payload = this.cache.get(key);
+        if (!payload) {
+            payload = makeGroupBoardColumns(groups, cols, tasks);
+            this.cache.set(key, payload);
+        }
+        return payload;
+    }
+}

--- a/sample/bench/bench.module.ts
+++ b/sample/bench/bench.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ResponseModule } from '../../lib/modules/response.module';
+import { BenchController } from './bench.controller';
+
+@Module({
+    imports: [
+        ResponseModule.forRoot({
+            excludedKeys: ['password', 'otpSecretKey', 'accessKeySecret']
+        })
+    ],
+    controllers: [BenchController]
+})
+export class BenchModule {}

--- a/sample/bench/response-bench.spec.ts
+++ b/sample/bench/response-bench.spec.ts
@@ -1,0 +1,148 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { BoardColumnResponse, GroupBoardColumnResponse } from './responses/board.responses';
+import { makeBoardColumns, makeGroupBoardColumns } from './responses/board.fixtures';
+
+const EXCLUDE_KEYS = ['password', 'otpSecretKey', 'accessKeySecret'];
+
+function excludeByKeys(data: unknown, keys: string[]): unknown {
+    if (data === null || typeof data !== 'object') {
+        return data;
+    }
+    if (Array.isArray(data)) {
+        return data.map((item) => excludeByKeys(item, keys));
+    }
+    const record = data as Record<string, unknown>;
+    for (const prop in record) {
+        if (keys.includes(prop)) {
+            delete record[prop];
+        } else if (record[prop] && typeof record[prop] === 'object') {
+            record[prop] = excludeByKeys(record[prop], keys);
+        }
+    }
+    return record;
+}
+
+function bench(label: string, fn: () => void, iterations: number, warmup: number): void {
+    for (let i = 0; i < warmup; i++) {
+        fn();
+    }
+
+    const samples: number[] = [];
+    for (let i = 0; i < iterations; i++) {
+        const start = process.hrtime.bigint();
+        fn();
+        const end = process.hrtime.bigint();
+        samples.push(Number(end - start) / 1_000_000);
+    }
+    samples.sort((a, b) => a - b);
+    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+    const p50 = samples[Math.floor(samples.length * 0.5)];
+    const p95 = samples[Math.floor(samples.length * 0.95)];
+
+    process.stdout.write(
+        `${label.padEnd(50)} mean=${mean.toFixed(2)}ms  p50=${p50.toFixed(2)}ms  p95=${p95.toFixed(2)}ms  ops/s=${(1000 / mean).toFixed(1)}\n`
+    );
+}
+
+function stockPath<T>(cls: new () => T, data: unknown[]): T[] {
+    const results: T[] = [];
+    for (const item of data) {
+        const instance = plainToInstance(cls, item) as T;
+        const errors = validateSync(instance as object, {
+            whitelist: true,
+            stopAtFirstError: true
+        });
+        if (errors.length > 0) {
+            throw new Error(`validateSync failed: ${JSON.stringify(errors[0])}`);
+        }
+        results.push(instance);
+    }
+    excludeByKeys(results, EXCLUDE_KEYS);
+    return results;
+}
+
+function fastPath<T>(cls: new () => T, data: unknown[]): T[] {
+    return data.map((item) => plainToInstance(cls, item) as T);
+}
+
+describe('Response interceptor benchmark', () => {
+    it('runs benchmark', () => {
+        const smallBoards = makeBoardColumns(5, 10);
+        const mediumBoards = makeBoardColumns(5, 50);
+
+        const smallGroup = makeGroupBoardColumns(5, 5, 5);
+        const mediumGroup = makeGroupBoardColumns(5, 5, 10);
+
+        try {
+            stockPath(BoardColumnResponse, smallBoards);
+            stockPath(GroupBoardColumnResponse, smallGroup);
+        } catch (err) {
+            process.stdout.write(`Fixture validation failed: ${err}\n`);
+            throw err;
+        }
+
+        process.stdout.write('\n=== BoardColumnResponse[] ===\n\n');
+        process.stdout.write('Small: 5 cols x 10 tasks (50 tasks, 100 attachments)\n');
+        bench('  stock', () => stockPath(BoardColumnResponse, smallBoards), 30, 5);
+        bench('  fast ', () => fastPath(BoardColumnResponse, smallBoards), 30, 5);
+
+        process.stdout.write('\nMedium: 5 cols x 50 tasks (250 tasks, 500 attachments)\n');
+        bench('  stock', () => stockPath(BoardColumnResponse, mediumBoards), 15, 3);
+        bench('  fast ', () => fastPath(BoardColumnResponse, mediumBoards), 15, 3);
+
+        process.stdout.write('\n=== GroupBoardColumnResponse[] ===\n\n');
+        process.stdout.write('Small: 5 groups x 5 cols x 5 tasks (125 tasks, 250 attachments)\n');
+        bench('  stock', () => stockPath(GroupBoardColumnResponse, smallGroup), 30, 5);
+        bench('  fast ', () => fastPath(GroupBoardColumnResponse, smallGroup), 30, 5);
+
+        process.stdout.write('\nMedium: 5 groups x 5 cols x 10 tasks (250 tasks, 500 attachments)\n');
+        bench('  stock', () => stockPath(GroupBoardColumnResponse, mediumGroup), 15, 3);
+        bench('  fast ', () => fastPath(GroupBoardColumnResponse, mediumGroup), 15, 3);
+
+        process.stdout.write('\n');
+    }, 600000);
+
+    it('breakdown: which part of stock costs what?', () => {
+        const data = makeGroupBoardColumns(5, 5, 10);
+
+        const countNodes = (obj: unknown): number => {
+            if (obj === null || typeof obj !== 'object') {
+                return 0;
+            }
+            if (Array.isArray(obj)) {
+                return obj.reduce<number>((sum, item) => sum + countNodes(item), 0);
+            }
+            let n = 1;
+            for (const key in obj as Record<string, unknown>) {
+                n += countNodes((obj as Record<string, unknown>)[key]);
+            }
+            return n;
+        };
+
+        const totalNodes = countNodes(data);
+        process.stdout.write(
+            `\n=== Breakdown (payload: 5 groups x 5 cols x 10 tasks, ~${totalNodes} nodes) ===\n\n`
+        );
+
+        const instances = data.map((d) => plainToInstance(GroupBoardColumnResponse, d));
+
+        const flatData = data.map((d) => ({ ...(d as object), boards: [] }));
+        const flatInstances = flatData.map((d) => plainToInstance(GroupBoardColumnResponse, d));
+
+        bench('  [1] plainToInstance only                            ', () => data.map((d) => plainToInstance(GroupBoardColumnResponse, d)), 30, 5);
+        bench('  [2] validateSync({}) recursive via @ValidateNested  ', () => instances.forEach((i) => validateSync(i)), 30, 5);
+        bench('  [3] validateSync({whitelist:true}) recursive        ', () => instances.forEach((i) => validateSync(i, { whitelist: true })), 30, 5);
+        bench('  [4] validateSync({whitelist,stopAtFirstError}) STOCK', () => instances.forEach((i) => validateSync(i, { whitelist: true, stopAtFirstError: true })), 30, 5);
+        bench('  [5] validateSync({whitelist:true}) NO nested        ', () => flatInstances.forEach((i) => validateSync(i, { whitelist: true })), 30, 5);
+        bench('  [6] excludeByKeys (recursive prop strip)            ', () => excludeByKeys(JSON.parse(JSON.stringify(data)), EXCLUDE_KEYS), 30, 5);
+
+        process.stdout.write('\nInterpretation:\n');
+        process.stdout.write('  [1] is the work shared by both decorators (plainToInstance)\n');
+        process.stdout.write('  [4] - [1] = total stock interceptor overhead per payload\n');
+        process.stdout.write('  [5] = validateSync overhead WITHOUT @ValidateNested recursion (root only)\n');
+        process.stdout.write('  [4] - [5] = cost of @ValidateNested recursing into all nested instances\n');
+        process.stdout.write('  [3] - [2] = whitelist-stripping overhead alone\n');
+        process.stdout.write('  [6] = excludeByKeys walk cost\n\n');
+    }, 600000);
+});

--- a/sample/bench/responses/board.fixtures.ts
+++ b/sample/bench/responses/board.fixtures.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from 'crypto';
+import {
+    BoardColumnResponse,
+    FileType,
+    FileUploadStatus,
+    GroupBoardColumnResponse,
+    Priority,
+    TaskType
+} from './board.responses';
+
+export function makeStatus(): unknown {
+    return {
+        id: randomUUID(),
+        name: 'In Progress',
+        position: 1,
+        projectId: randomUUID(),
+        category: {
+            id: randomUUID(),
+            name: 'In Progress',
+            color: 'blue'
+        }
+    };
+}
+
+export function makeAttachment(): unknown {
+    return {
+        id: randomUUID(),
+        name: 'image.png',
+        path: 'image.png_2026-05-20',
+        fileType: FileType.IMAGE,
+        refType: 'IMAGE',
+        refId: randomUUID(),
+        size: 1024,
+        status: FileUploadStatus.SUCCESS,
+        userId: randomUUID(),
+        signedUrl: 'https://example.s3.amazonaws.com/image.png'
+    };
+}
+
+export function makeBoardTask(): unknown {
+    return {
+        id: randomUUID(),
+        key: 'ABC-1',
+        summary: 'Implement feature X',
+        type: TaskType.TASK,
+        priority: Priority.MEDIUM,
+        statusId: randomUUID(),
+        assigneeId: randomUUID(),
+        labels: [],
+        sprintId: randomUUID(),
+        isFlagged: false,
+        storyPoint: 3,
+        attachments: [makeAttachment(), makeAttachment()]
+    };
+}
+
+export function makeBoardColumnItem(): unknown {
+    return {
+        id: randomUUID(),
+        boardColumnId: randomUUID(),
+        taskId: randomUUID(),
+        position: 1,
+        task: makeBoardTask()
+    };
+}
+
+export function makeBoardColumn(taskCount: number): unknown {
+    return {
+        id: randomUUID(),
+        status: makeStatus(),
+        projectId: randomUUID(),
+        limit: 100,
+        items: Array.from({ length: taskCount }, () => makeBoardColumnItem()),
+        itemCount: taskCount,
+        isOverLimit: false
+    };
+}
+
+export function makeGroupBoardColumn(columnCount: number, taskPerColumn: number): unknown {
+    return {
+        group: {
+            id: randomUUID()
+        },
+        taskCount: columnCount * taskPerColumn,
+        boards: Array.from({ length: columnCount }, () => makeBoardColumn(taskPerColumn))
+    };
+}
+
+export function makeBoardColumns(columnCount: number, taskPerColumn: number): unknown[] {
+    return Array.from({ length: columnCount }, () => makeBoardColumn(taskPerColumn));
+}
+
+export function makeGroupBoardColumns(groupCount: number, columnPerGroup: number, taskPerColumn: number): unknown[] {
+    return Array.from({ length: groupCount }, () => makeGroupBoardColumn(columnPerGroup, taskPerColumn));
+}
+
+export type AnyResponseClass = typeof BoardColumnResponse | typeof GroupBoardColumnResponse;

--- a/sample/bench/responses/board.responses.ts
+++ b/sample/bench/responses/board.responses.ts
@@ -1,0 +1,254 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+    IsArray,
+    IsBoolean,
+    IsEnum,
+    IsNumber,
+    IsOptional,
+    IsString,
+    IsUUID,
+    ValidateNested
+} from 'class-validator';
+
+export enum TaskType {
+    TASK = 'TASK',
+    STORY = 'STORY',
+    EPIC = 'EPIC',
+    BUG = 'BUG'
+}
+
+export enum Priority {
+    LOW = 'LOW',
+    MEDIUM = 'MEDIUM',
+    HIGH = 'HIGH',
+    CRITICAL = 'CRITICAL'
+}
+
+export enum FileType {
+    IMAGE = 'IMAGE',
+    VIDEO = 'VIDEO',
+    AUDIO = 'AUDIO',
+    DOCUMENT = 'DOCUMENT'
+}
+
+export enum FileUploadStatus {
+    PENDING = 'PENDING',
+    SUCCESS = 'SUCCESS',
+    FAILED = 'FAILED'
+}
+
+export class CategoryResponse {
+    @ApiProperty()
+    @IsUUID()
+    id: string;
+
+    @ApiProperty()
+    @IsString()
+    name: string;
+
+    @ApiProperty()
+    @IsString()
+    color: string;
+}
+
+export class StatusResponse {
+    @ApiProperty()
+    @IsUUID()
+    id: string;
+
+    @ApiProperty()
+    @IsString()
+    name: string;
+
+    @ApiProperty()
+    @IsNumber()
+    position: number;
+
+    @ApiProperty()
+    @IsUUID()
+    projectId: string;
+
+    @ApiProperty({ type: () => CategoryResponse })
+    @Type(() => CategoryResponse)
+    @ValidateNested()
+    category: CategoryResponse;
+}
+
+export class AttachmentResponse {
+    @ApiProperty()
+    @IsUUID()
+    id: string;
+
+    @ApiProperty()
+    @IsString()
+    name: string;
+
+    @ApiProperty()
+    @IsString()
+    path: string;
+
+    @ApiProperty({ enum: FileType })
+    @IsEnum(FileType)
+    fileType: FileType;
+
+    @ApiProperty()
+    @IsString()
+    refType: string;
+
+    @ApiProperty()
+    @IsUUID()
+    refId: string;
+
+    @ApiProperty()
+    @IsNumber()
+    size: number;
+
+    @ApiProperty({ enum: FileUploadStatus })
+    @IsEnum(FileUploadStatus)
+    status: FileUploadStatus;
+
+    @ApiProperty()
+    @IsUUID()
+    userId: string;
+
+    @ApiProperty()
+    @IsString()
+    signedUrl: string;
+}
+
+export class BoardTaskResponse {
+    @ApiProperty()
+    @IsUUID()
+    id: string;
+
+    @ApiProperty()
+    @IsString()
+    key: string;
+
+    @ApiProperty()
+    @IsString()
+    summary: string;
+
+    @ApiProperty({ enum: TaskType })
+    @IsEnum(TaskType)
+    type: TaskType;
+
+    @ApiProperty({ enum: Priority })
+    @IsEnum(Priority)
+    priority: Priority;
+
+    @ApiProperty()
+    @IsUUID()
+    statusId: string;
+
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsUUID()
+    assigneeId?: string;
+
+    @ApiProperty({ type: [String] })
+    @IsArray()
+    @IsString({ each: true })
+    labels: string[];
+
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsUUID()
+    sprintId?: string;
+
+    @ApiProperty()
+    @IsBoolean()
+    isFlagged: boolean;
+
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsNumber()
+    storyPoint?: number;
+
+    @ApiProperty({ type: () => [AttachmentResponse] })
+    @IsArray()
+    @Type(() => AttachmentResponse)
+    @ValidateNested({ each: true })
+    attachments: AttachmentResponse[];
+}
+
+export class BoardColumnItemResponse {
+    @ApiProperty()
+    @IsUUID()
+    id: string;
+
+    @ApiProperty()
+    @IsUUID()
+    boardColumnId: string;
+
+    @ApiProperty()
+    @IsUUID()
+    taskId: string;
+
+    @ApiProperty()
+    @IsNumber()
+    position: number;
+
+    @ApiProperty({ type: () => BoardTaskResponse })
+    @Type(() => BoardTaskResponse)
+    @ValidateNested()
+    task: BoardTaskResponse;
+}
+
+export class BoardColumnResponse {
+    @ApiProperty()
+    @IsUUID()
+    id: string;
+
+    @ApiProperty({ type: () => StatusResponse })
+    @Type(() => StatusResponse)
+    @ValidateNested()
+    status: StatusResponse;
+
+    @ApiProperty()
+    @IsUUID()
+    projectId: string;
+
+    @ApiProperty()
+    @IsNumber()
+    limit: number;
+
+    @ApiProperty({ type: () => [BoardColumnItemResponse] })
+    @IsArray()
+    @Type(() => BoardColumnItemResponse)
+    @ValidateNested({ each: true })
+    items: BoardColumnItemResponse[];
+
+    @ApiProperty()
+    @IsNumber()
+    itemCount: number;
+
+    @ApiProperty()
+    @IsBoolean()
+    isOverLimit: boolean;
+}
+
+export class GroupResponse {
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsUUID()
+    id?: string;
+}
+
+export class GroupBoardColumnResponse {
+    @ApiProperty({ type: () => GroupResponse })
+    @Type(() => GroupResponse)
+    @ValidateNested()
+    group: GroupResponse;
+
+    @ApiProperty()
+    @IsNumber()
+    taskCount: number;
+
+    @ApiProperty({ type: () => [BoardColumnResponse] })
+    @IsArray()
+    @Type(() => BoardColumnResponse)
+    @ValidateNested({ each: true })
+    boards: BoardColumnResponse[];
+}


### PR DESCRIPTION
## Summary

Adds a benchmark suite under `sample/bench/` to measure the cost of `plainToInstance` + `validateSync` + `@ValidateNested` recursion on deeply nested response payloads. Useful for evaluating the runtime cost of the response interceptor on large kanban/list-style responses, and for guiding decisions about per-endpoint validation strategies.

## What's added

- `sample/bench/responses/board.responses.ts` — self-contained response classes mirroring a realistic deeply nested shape (groups → columns → items → task → attachments). No project dependencies, just `class-validator` / `class-transformer` / `@nestjs/swagger`.
- `sample/bench/responses/board.fixtures.ts` — data generators (`makeBoardColumn`, `makeGroupBoardColumn`).
- `sample/bench/response-bench.spec.ts` — synthetic benchmark with two tests:
  - `runs benchmark` compares the full stock path (`plainToInstance` + `validateSync({whitelist, stopAtFirstError})` + `excludeByKeys`) vs a fast path (`plainToInstance` only) across small and medium payloads.
  - `breakdown` isolates the cost of each step so it's easy to see where the time goes — in particular, how much is `@ValidateNested` recursion vs root-only validation vs `excludeByKeys`.
- `sample/bench/bench.controller.ts` + `bench.module.ts` + `bench-http.spec.ts` — HTTP-level bench: bootstraps a real Nest app via `@nestjs/testing`, exposes a `GET /bench/group-boards` endpoint using `@ResponseModel(GroupBoardColumnResponse, true)`, hits it via `supertest`, and reports mean/p50/p95 latency.
- `package.json` — adds `moduleDirectories: ["node_modules", "<rootDir>"]` to the Jest config so that the library's internal `baseUrl`-style imports (e.g. `lib/constants/provider-key.constant`) resolve under `ts-jest`. Without this, the existing `moduleNameMapper` is not enough for any spec that imports `ResponseModule`.

## Sample output

Synthetic breakdown on a ~1085-node payload (5 groups × 5 columns × 10 tasks):

```
[1] plainToInstance only                             mean=41.24ms
[2] validateSync({}) recursive via @ValidateNested   mean=12.19ms
[3] validateSync({whitelist:true}) recursive         mean=15.08ms
[4] validateSync({whitelist,stopAtFirstError}) STOCK mean=12.99ms
[5] validateSync({whitelist:true}) NO nested         mean= 0.03ms
[6] excludeByKeys (recursive prop strip)             mean= 1.31ms
```

`[5]` vs `[4]` shows that with `@ValidateNested` removed, `validateSync` cost drops by ~400×.

HTTP-level on a 1000-task payload:

```
HTTP bench /bench/group-boards  (1000 tasks, 2000 attachments)
  samples=10  mean=558.6ms  p50=571.7ms  p95=690.6ms
```

## Test plan

- [x] `npx jest sample/bench/response-bench.spec.ts` — both tests pass
- [x] `npx jest sample/bench/bench-http.spec.ts` — passes and reports latency
- [x] Existing tests still pass (`npx jest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)