### PR TITLE
fix: cache plan eagerly to support self-referential responses

### DIFF
--- a/lib/utils/transform.util.ts
+++ b/lib/utils/transform.util.ts
@@ -66,7 +66,7 @@ export function applyTransforms<T extends object>(
     if (!storage) {
         return data;
     }
-    const plan = getOrBuildPlan(target, storage, new Set());
+    const plan = getOrBuildPlan(target, storage);
     if (!plan.propertyTransforms.length && !plan.nestedPlans.length) {
         return data;
     }
@@ -140,29 +140,22 @@ function matchesVersion(metaOptions: TransformOptions | undefined, callOptions: 
     return (since === undefined || version >= since) && (until === undefined || version < until);
 }
 
-function getOrBuildPlan(target: Function, storage: MetadataStorage, visiting: Set<Function>): TransformPlan {
+function getOrBuildPlan(target: Function, storage: MetadataStorage): TransformPlan {
     const cached = planCache.get(target);
     if (cached) {
         return cached;
     }
-    if (visiting.has(target)) {
-        return { propertyTransforms: [], nestedPlans: [] };
-    }
-    visiting.add(target);
+    const plan: TransformPlan = { propertyTransforms: [], nestedPlans: [] };
+    planCache.set(target, plan);
 
-    const propertyTransforms: PropertyTransform[] = [];
-    const nestedPlans: NestedPlan[] = [];
     const seenTransform = new Set<string>();
     const seenNested = new Set<string>();
 
     for (const cls of collectClassChain(target)) {
-        collectPropertyTransforms(cls, storage, seenTransform, propertyTransforms);
-        collectNestedPlans(cls, storage, visiting, seenNested, nestedPlans);
+        collectPropertyTransforms(cls, storage, seenTransform, plan.propertyTransforms);
+        collectNestedPlans(cls, storage, seenNested, plan.nestedPlans);
     }
 
-    const plan: TransformPlan = { propertyTransforms, nestedPlans };
-    visiting.delete(target);
-    planCache.set(target, plan);
     return plan;
 }
 
@@ -194,13 +187,7 @@ function collectPropertyTransforms(
     }
 }
 
-function collectNestedPlans(
-    cls: Function,
-    storage: MetadataStorage,
-    visiting: Set<Function>,
-    seen: Set<string>,
-    out: NestedPlan[]
-): void {
+function collectNestedPlans(cls: Function, storage: MetadataStorage, seen: Set<string>, out: NestedPlan[]): void {
     const typeMap = storage._typeMetadatas.get(cls);
     if (!typeMap) {
         return;
@@ -214,10 +201,8 @@ function collectNestedPlans(
         if (!nestedClass) {
             continue;
         }
-        const nestedPlan = getOrBuildPlan(nestedClass, storage, visiting);
-        if (nestedPlan.propertyTransforms.length > 0 || nestedPlan.nestedPlans.length > 0) {
-            out.push({ propertyName, plan: nestedPlan });
-        }
+        const nestedPlan = getOrBuildPlan(nestedClass, storage);
+        out.push({ propertyName, plan: nestedPlan });
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-response",
-    "version": "11.1.0",
+    "version": "11.1.1",
     "description": "Standardizes and validates API responses in NestJS for consistent and reliable communication",
     "author": "",
     "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

- Cache the in-progress plan in `planCache` before recursing into nested classes so that self-referential response types resolve to a stable, shared plan instead of being dropped as empty placeholders.
- Removes the `visiting` set / empty-plan short-circuit in `getOrBuildPlan`, and the `if (nestedPlan.propertyTransforms.length > 0 || nestedPlan.nestedPlans.length > 0)` filter in `collectNestedPlans` that was filtering out the cycle.

## Why

Caught in `employer-backend` chat tests after upgrading to `@hodfords/nestjs-response@11.1.0`. A `ChatMessageResponse` whose `referencedMessage` is itself a `ChatMessageResponse` would lose its property transforms — the recursive call returned `{ propertyTransforms: [], nestedPlans: [] }`, then the empty plan was filtered out, so transforms attached to the referenced message were silently dropped (7 e2e failures).

After this fix, the plan inserted before recursion is the same reference returned to the inner call. As subsequent loop iterations mutate `plan.propertyTransforms` and `plan.nestedPlans`, the inner reference sees the updates. The cycle in the plan structure mirrors the cycle in the data; `runPlan` terminates naturally when the data graph terminates.

## Test plan

- [x] `npm run build` — clean tsc build, generated JS is byte-identical to the patched JS we are running in production.
- [x] Verified in `employer-backend` chat e2e: 7 previously-failing `referencedMessage` assertions now pass with the patched JS this PR produces.
- [ ] Add a regression unit test for self-referential response types (left for follow-up unless you'd like it bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)