### PR TITLE
fix(interceptor): use __sendData group for gRPC outgoing responses

### DIFF
--- a/lib/interceptors/response.interceptor.spec.ts
+++ b/lib/interceptors/response.interceptor.spec.ts
@@ -1,0 +1,130 @@
+import 'reflect-metadata';
+import { ExecutionContext } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { Metadata } from '@grpc/grpc-js';
+import { Allow, IsOptional, ValidateNested } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { ResponseInterceptor } from './response.interceptor';
+import { RESPONSE_METADATA_KEY } from '../constants/metadata.constant';
+import { ResponseModel } from '../decorators/response-model.decorator';
+
+/**
+ * Minimal stand-in for `@AnyType()` from `@hodfords/nestjs-grpc-helper`: serializes
+ * arbitrary JS values into a JSON string on the gRPC outgoing path (`__sendData`),
+ * and parses them back on the gRPC incoming path (`__getData`).
+ */
+function AnyTypeStub(): PropertyDecorator {
+    return Transform(({ value, options }) => {
+        if (options.groups?.includes('__sendData')) {
+            return JSON.stringify(value);
+        }
+        if (options.groups?.includes('__getData')) {
+            if (typeof value !== 'string') return value;
+            try {
+                return JSON.parse(value);
+            } catch {
+                return value;
+            }
+        }
+        return value;
+    });
+}
+
+class NestedDetailResponse {
+    @Allow()
+    name?: string;
+}
+
+class HistoryValueResponse {
+    @AnyTypeStub()
+    @Allow()
+    value?: unknown;
+
+    @AnyTypeStub()
+    @IsOptional()
+    @Type(() => NestedDetailResponse)
+    @ValidateNested({ each: true })
+    details?: NestedDetailResponse[] | null;
+}
+
+class HistoryMetadataResponse {
+    @Type(() => HistoryValueResponse)
+    @ValidateNested()
+    before!: HistoryValueResponse;
+
+    @Type(() => HistoryValueResponse)
+    @ValidateNested()
+    after!: HistoryValueResponse;
+}
+
+class HistoryResponse {
+    @Allow()
+    id!: string;
+
+    @Type(() => HistoryMetadataResponse)
+    @ValidateNested()
+    metadata!: HistoryMetadataResponse;
+}
+
+function buildContext(rpcContext: unknown): ExecutionContext {
+    const handler = function findHistories() {};
+    Reflect.defineMetadata(
+        RESPONSE_METADATA_KEY,
+        { responseClass: HistoryResponse, isArray: false, isAllowEmpty: false },
+        handler
+    );
+    return {
+        getHandler: () => handler,
+        switchToRpc: () => ({ getContext: () => rpcContext }),
+        switchToHttp: () => undefined as any,
+        switchToWs: () => undefined as any
+    } as unknown as ExecutionContext;
+}
+
+function buildInterceptor(): ResponseInterceptor {
+    const moduleRef = { get: () => undefined } as unknown as ModuleRef;
+    return new ResponseInterceptor(moduleRef);
+}
+
+function buildPayload(): Record<string, any> {
+    return {
+        id: 'h-1',
+        metadata: {
+            before: { value: [{ a: 1 }, { a: 2 }], details: null },
+            after: { value: [{ b: 1 }, { b: 2 }], details: null }
+        }
+    };
+}
+
+describe('ResponseInterceptor — gRPC outgoing transform group', () => {
+    it('JSON.stringifies an array `@AnyType` value when the context is gRPC, so proto `string` fields receive valid JSON (not "[object Object],[object Object]")', () => {
+        const interceptor = buildInterceptor();
+        const data = buildPayload();
+
+        const result = interceptor.handleResponse(buildContext(new Metadata()), data) as any;
+
+        expect(typeof result.metadata.before.value).toBe('string');
+        expect(JSON.parse(result.metadata.before.value)).toEqual([{ a: 1 }, { a: 2 }]);
+        expect(typeof result.metadata.after.value).toBe('string');
+        expect(JSON.parse(result.metadata.after.value)).toEqual([{ b: 1 }, { b: 2 }]);
+    });
+
+    it('leaves the `@AnyType` value as-is on the HTTP path so the JSON response carries arrays/objects (not stringified blobs)', () => {
+        const interceptor = buildInterceptor();
+        const data = buildPayload();
+
+        const result = interceptor.handleResponse(buildContext({}), data) as any;
+
+        expect(Array.isArray(result.metadata.before.value)).toBe(true);
+        expect(result.metadata.before.value).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('validates the *original* payload (so nullable nested fields like `details: null` keep skipping `@ValidateNested` via `@IsOptional`)', () => {
+        const interceptor = buildInterceptor();
+        const data = buildPayload();
+
+        expect(() => interceptor.handleResponse(buildContext(new Metadata()), data)).not.toThrow();
+        // After the call, `details` is still expected to be JSON-stringified for the wire:
+        expect((data as any).metadata.before.details).toBe('null');
+    });
+});

--- a/lib/interceptors/response.interceptor.ts
+++ b/lib/interceptors/response.interceptor.ts
@@ -153,10 +153,9 @@ export class ResponseInterceptor implements NestInterceptor {
             return this.handleNativeValueResponse(responseMetadata, data);
         }
 
-        // Apply only @Transform decorators in-place — skips full plainToInstance for performance.
-        applyTransforms(data, responseMetadata.responseClass, { groups: ['__getData'] });
-
-        // use validatePlainSync to increase performance, because we only need to validate the plain object, not transform it to class instance
+        // Validate first so we see the original payload — applying `__sendData` first
+        // would JSON.stringify nullable nested fields (e.g. `null` → `"null"`) and break
+        // downstream `@ValidateNested` / `@IsOptional` checks.
         const errors = validatePlainSync(data, responseMetadata.responseClass, {
             whitelist: true,
             stopAtFirstError: true
@@ -164,6 +163,17 @@ export class ResponseInterceptor implements NestInterceptor {
         if (errors.length) {
             throw new ResponseValidateException(errors);
         }
+
+        // Then run transforms with the group that matches the *outgoing* wire format:
+        //   - gRPC: `__sendData` so `@AnyType` JSON.stringify's array/object values into
+        //     proto `string` fields (otherwise protobuf coerces via `String([...])`
+        //     and the receiver sees `"[object Object],[object Object]"`).
+        //   - HTTP: no group — values pass through and Express/Nest JSON-serializes
+        //     the whole response.
+        const isGrpc = grpcMetadataClass && context.switchToRpc().getContext() instanceof grpcMetadataClass;
+        const groups = isGrpc ? ['__sendData', '__grpc'] : [];
+        applyTransforms(data, responseMetadata.responseClass, { groups });
+
         return data;
     }
 


### PR DESCRIPTION
## Summary

Since 11.1.0 `ResponseInterceptor.handleSingleResponse` applies the `__getData` group to **every** response — both HTTP and gRPC. That breaks gRPC outgoing serialization for `@AnyType()`-decorated fields whose proto type is `string`:

- `@AnyType()`'s `__getData` branch only `JSON.parse`s strings; an `Array` / `Object` value passes through unchanged.
- The gRPC layer then has to encode that value into a `string` proto field. `protobufjs` falls back to `String([...])`, producing the literal `"[object Object],[object Object]"` on the wire.
- Receivers then JSON.parse that string, hit `SyntaxError`, and either 500 (rc.36/37 of `nestjs-grpc-helper`) or — once the parse is guarded — surface the corrupt string in the API response.

This restores the pre-11.1.0 behavior:

- gRPC context → `['__sendData', '__grpc']` → `@AnyType()` `JSON.stringify`s the value into valid JSON.
- HTTP context → no group → values pass through; Express/Nest's JSON serializer handles arrays/objects natively.

Validation is also reordered to run **before** the transform pass. Otherwise `@Transform` would `JSON.stringify` a nullable nested field (e.g. ``details: null`` → ``\"null\"``) and `@IsOptional` / `@ValidateNested` would then reject the stringified blob.

## Repro (without this fix)

In a downstream service whose proto has `string value = 1;` for an `@AnyType()` field and whose DB column stores an array:

1. Activity service returns `metadata.before.value = [block1, block2]` via gRPC.
2. 11.1.x interceptor runs `applyTransforms(..., { groups: ['__getData'] })` → array stays an array.
3. `@grpc/proto-loader` coerces the array to the proto `string` field via `String([...])`.
4. Client receives `value: \"[object Object],[object Object]\"`.

## Test plan

New `lib/interceptors/response.interceptor.spec.ts` (run with `npm test response.interceptor`):

- [x] gRPC context: array `@AnyType` value is `JSON.stringify`'d so the proto `string` field carries valid JSON.
- [x] HTTP context: array `@AnyType` value passes through unchanged (the response interceptor doesn't pre-serialize for Express).
- [x] Nullable nested fields (`details: null` with `@ValidateNested` + `@IsOptional`) no longer trip validation after the reorder.

Existing tests still pass — `npm test`: ✅ 3 suites / 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)