### PR TITLE
chore: fix lint on regression test and bump to 11.1.4

### DIFF
--- a/lib/interceptors/response.interceptor.spec.ts
+++ b/lib/interceptors/response.interceptor.spec.ts
@@ -6,15 +6,15 @@ import { Allow, IsOptional, ValidateNested } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ResponseInterceptor } from './response.interceptor';
 import { RESPONSE_METADATA_KEY } from '../constants/metadata.constant';
-import { ResponseModel } from '../decorators/response-model.decorator';
 
 /**
  * Minimal stand-in for `@AnyType()` from `@hodfords/nestjs-grpc-helper`: serializes
  * arbitrary JS values into a JSON string on the gRPC outgoing path (`__sendData`),
  * and parses them back on the gRPC incoming path (`__getData`).
  */
-function AnyTypeStub(): PropertyDecorator {
-    return Transform(({ value, options }) => {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const AnyTypeStub = (): PropertyDecorator =>
+    Transform(({ value, options }) => {
         if (options.groups?.includes('__sendData')) {
             return JSON.stringify(value);
         }
@@ -28,7 +28,6 @@ function AnyTypeStub(): PropertyDecorator {
         }
         return value;
     });
-}
 
 class NestedDetailResponse {
     @Allow()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-response",
-    "version": "11.1.3",
+    "version": "11.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-response",
-            "version": "11.1.3",
+            "version": "11.1.4",
             "license": "UNLICENSED",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-response",
-    "version": "11.1.3",
+    "version": "11.1.4",
     "description": "Standardizes and validates API responses in NestJS for consistent and reliable communication",
     "author": "",
     "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

Follow-up to #35. Two tiny issues from that PR:

1. **Lint broke `main`** — the new regression test tripped eslint:
   - `'ResponseModel' is defined but never used`
   - `Function name 'AnyTypeStub' must match one of the following formats: camelCase`

   Fixed by:
   - dropping the unused `ResponseModel` import
   - converting `function AnyTypeStub()` → `const AnyTypeStub = (): PropertyDecorator => ...` with the standard `// eslint-disable-next-line @typescript-eslint/naming-convention` comment — matches the existing `ToUnix` pattern in [`lib/utils/transform.util.spec.ts`](../blob/main/lib/utils/transform.util.spec.ts).

2. **Version bump** — `11.1.3 → 11.1.4` in `package.json` + `package-lock.json` so the gRPC fix can be published.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test response.interceptor` — 3/3 passing
- [x] `npm test` — full suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)