### PR TITLE
refactor(interceptor): single-pass transform + validate (requires nestjs-grpc-helper >= 11.3.7)

### DIFF
--- a/lib/interceptors/response.interceptor.spec.ts
+++ b/lib/interceptors/response.interceptor.spec.ts
@@ -3,30 +3,34 @@ import { ExecutionContext } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { Metadata } from '@grpc/grpc-js';
 import { Allow, IsOptional, ValidateNested } from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { plainToInstance, Transform, Type } from 'class-transformer';
 import { ResponseInterceptor } from './response.interceptor';
 import { RESPONSE_METADATA_KEY } from '../constants/metadata.constant';
 
 /**
- * Minimal stand-in for `@AnyType()` from `@hodfords/nestjs-grpc-helper`: serializes
- * arbitrary JS values into a JSON string on the gRPC outgoing path (`__sendData`),
- * and parses them back on the gRPC incoming path (`__getData`).
+ * Minimal stand-in for `@AnyType()` from `@hodfords/nestjs-grpc-helper@>=11.3.7`:
+ * runs both `__getData` (JSON.parse string → object) and `__sendData`
+ * (JSON.stringify non-nullish → string) in a single transform call. The null
+ * guard is what makes the single-pass `transform-then-validate` flow safe —
+ * without it, `JSON.stringify(null)` would turn into the string `"null"`
+ * before validation and break `@ValidateNested` + `@IsOptional`.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const AnyTypeStub = (): PropertyDecorator =>
     Transform(({ value, options }) => {
-        if (options.groups?.includes('__sendData')) {
-            return JSON.stringify(value);
-        }
-        if (options.groups?.includes('__getData')) {
-            if (typeof value !== 'string') return value;
+        const groups = options.groups ?? [];
+        let next = value;
+        if (groups.includes('__getData') && typeof next === 'string') {
             try {
-                return JSON.parse(value);
+                next = JSON.parse(next);
             } catch {
-                return value;
+                /* keep raw */
             }
         }
-        return value;
+        if (groups.includes('__sendData') && next !== null && next !== undefined) {
+            next = JSON.stringify(next);
+        }
+        return next;
     });
 
 class NestedDetailResponse {
@@ -65,13 +69,9 @@ class HistoryResponse {
     metadata!: HistoryMetadataResponse;
 }
 
-function buildContext(rpcContext: unknown): ExecutionContext {
+function buildContextFor(responseClass: any, rpcContext: unknown): ExecutionContext {
     const handler = function findHistories() {};
-    Reflect.defineMetadata(
-        RESPONSE_METADATA_KEY,
-        { responseClass: HistoryResponse, isArray: false, isAllowEmpty: false },
-        handler
-    );
+    Reflect.defineMetadata(RESPONSE_METADATA_KEY, { responseClass, isArray: false, isAllowEmpty: false }, handler);
     return {
         getHandler: () => handler,
         switchToRpc: () => ({ getContext: () => rpcContext }),
@@ -95,12 +95,39 @@ function buildPayload(): Record<string, any> {
     };
 }
 
-describe('ResponseInterceptor — gRPC outgoing transform group', () => {
-    it('JSON.stringifies an array `@AnyType` value when the context is gRPC, so proto `string` fields receive valid JSON (not "[object Object],[object Object]")', () => {
+describe('ResponseInterceptor — HTTP path (`__getData` group)', () => {
+    it('leaves `@AnyType` values untouched when they are already objects/arrays (the common case) so HTTP responses carry raw JSON', () => {
         const interceptor = buildInterceptor();
         const data = buildPayload();
 
-        const result = interceptor.handleResponse(buildContext(new Metadata()), data) as any;
+        const result = interceptor.handleResponse(buildContextFor(HistoryResponse, {}), data) as any;
+
+        expect(Array.isArray(result.metadata.before.value)).toBe(true);
+        expect(result.metadata.before.value).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('runs `@AnyType` `__getData` JSON.parse so string-stored values (e.g. a JSONB column read as a string) are materialized before `@ValidateNested` iterates them', () => {
+        const interceptor = buildInterceptor();
+        const data = {
+            id: 'h-1',
+            metadata: {
+                before: { value: 1, details: '[{"name":"alice"}]' },
+                after: { value: 1, details: '[{"name":"bob"}]' }
+            }
+        };
+
+        expect(() => interceptor.handleResponse(buildContextFor(HistoryResponse, {}), data)).not.toThrow();
+        expect(Array.isArray((data as any).metadata.before.details)).toBe(true);
+        expect((data as any).metadata.before.details).toEqual([{ name: 'alice' }]);
+    });
+});
+
+describe('ResponseInterceptor — gRPC path (`__getData` + `__sendData` + `__grpc`)', () => {
+    it('JSON.stringifies array `@AnyType` values so proto `string` fields receive valid JSON (not "[object Object],[object Object]")', () => {
+        const interceptor = buildInterceptor();
+        const data = buildPayload();
+
+        const result = interceptor.handleResponse(buildContextFor(HistoryResponse, new Metadata()), data) as any;
 
         expect(typeof result.metadata.before.value).toBe('string');
         expect(JSON.parse(result.metadata.before.value)).toEqual([{ a: 1 }, { a: 2 }]);
@@ -108,22 +135,78 @@ describe('ResponseInterceptor — gRPC outgoing transform group', () => {
         expect(JSON.parse(result.metadata.after.value)).toEqual([{ b: 1 }, { b: 2 }]);
     });
 
-    it('leaves the `@AnyType` value as-is on the HTTP path so the JSON response carries arrays/objects (not stringified blobs)', () => {
+    it('leaves nullable nested fields as `null` so `@IsOptional` keeps skipping them — relies on the null/undefined-safe `__sendData` branch in `@AnyType` (nestjs-grpc-helper >= 11.3.7)', () => {
         const interceptor = buildInterceptor();
         const data = buildPayload();
 
-        const result = interceptor.handleResponse(buildContext({}), data) as any;
-
-        expect(Array.isArray(result.metadata.before.value)).toBe(true);
-        expect(result.metadata.before.value).toEqual([{ a: 1 }, { a: 2 }]);
+        expect(() => interceptor.handleResponse(buildContextFor(HistoryResponse, new Metadata()), data)).not.toThrow();
+        // null stays null after the single-pass transform. With pre-11.3.7 `@AnyType`
+        // (no null guard) the value would have been the string `"null"` here and
+        // `@ValidateNested` would have failed downstream.
+        expect((data as any).metadata.before.details).toBeNull();
     });
+});
 
-    it('validates the *original* payload (so nullable nested fields like `details: null` keep skipping `@ValidateNested` via `@IsOptional`)', () => {
+/**
+ * Polymorphic discriminator pattern: each block subtype is materialized via
+ * `@Transform({ toClassOnly: true })` based on a runtime `type` field. The base
+ * field is deliberately *not* pinned with `@Type(() => baseClass)` — pinning to a
+ * base would strip subtype-specific properties under `whitelist`, so
+ * `@ValidateNested` is expected to resolve each array element's class via the
+ * runtime constructor of the materialized instance.
+ *
+ * This mirrors `@hplix/block-helper`'s `@BlockDiscriminator` and is the canonical
+ * shape that broke between 11.1.3 and 11.1.4.
+ */
+class RichTextBlockDto {
+    @Allow() type!: 'richText';
+    @Allow() text!: string;
+}
+
+class DividerBlockDto {
+    @Allow() type!: 'divider';
+}
+
+const blockDiscriminatorMap = new Map<string, new () => any>([
+    ['richText', RichTextBlockDto],
+    ['divider', DividerBlockDto]
+]);
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BlockDiscriminatorStub = (): PropertyDecorator =>
+    Transform(
+        ({ value }) => {
+            if (!Array.isArray(value)) return value;
+            return value.map((item: any) => {
+                const ctor = item?.type ? blockDiscriminatorMap.get(item.type) : undefined;
+                return ctor ? plainToInstance(ctor, item) : item;
+            });
+        },
+        { toClassOnly: true }
+    );
+
+class DocumentTemplateResponse {
+    @Allow() id!: string;
+
+    @BlockDiscriminatorStub()
+    @IsOptional()
+    @ValidateNested({ each: true })
+    blocks?: any[];
+}
+
+describe('ResponseInterceptor — polymorphic discriminator runs before validation', () => {
+    it('materializes discriminator-based polymorphic items via the `__getData` pre-pass so `@ValidateNested` can resolve nested constructors at runtime', () => {
         const interceptor = buildInterceptor();
-        const data = buildPayload();
+        const data: Record<string, any> = {
+            id: 'doc-1',
+            blocks: [{ type: 'richText', text: 'hello' }, { type: 'divider' }]
+        };
 
-        expect(() => interceptor.handleResponse(buildContext(new Metadata()), data)).not.toThrow();
-        // After the call, `details` is still expected to be JSON-stringified for the wire:
-        expect((data as any).metadata.before.details).toBe('null');
+        // Without the `__getData` pre-pass, class-validator hits `blocks[0]` as a
+        // plain object with no constructor and throws
+        // `"an unknown value was passed to the validate function"`.
+        expect(() => interceptor.handleResponse(buildContextFor(DocumentTemplateResponse, {}), data)).not.toThrow();
+        expect(data.blocks[0]).toBeInstanceOf(RichTextBlockDto);
+        expect(data.blocks[1]).toBeInstanceOf(DividerBlockDto);
     });
 });

--- a/lib/interceptors/response.interceptor.ts
+++ b/lib/interceptors/response.interceptor.ts
@@ -153,9 +153,17 @@ export class ResponseInterceptor implements NestInterceptor {
             return this.handleNativeValueResponse(responseMetadata, data);
         }
 
-        // Validate first so we see the original payload — applying `__sendData` first
-        // would JSON.stringify nullable nested fields (e.g. `null` → `"null"`) and break
-        // downstream `@ValidateNested` / `@IsOptional` checks.
+        // Apply only @Transform decorators in-place — skips full plainToInstance for performance.
+        // The gRPC outgoing path adds the `__sendData` / `__grpc` groups so `@AnyType()`
+        // JSON.stringify's its value for the proto `string` field in the same walk.
+        // The null guard inside `@AnyType()` (nestjs-grpc-helper >= 11.3.7) keeps nullable
+        // `@ValidateNested` + `@IsOptional` fields working even though validation runs
+        // *after* the transform.
+        const isGrpc = grpcMetadataClass && context.switchToRpc().getContext() instanceof grpcMetadataClass;
+        const groups = isGrpc ? ['__getData', '__sendData', '__grpc'] : ['__getData'];
+        applyTransforms(data, responseMetadata.responseClass, { groups });
+
+        // use validatePlainSync to increase performance, because we only need to validate the plain object, not transform it to class instance
         const errors = validatePlainSync(data, responseMetadata.responseClass, {
             whitelist: true,
             stopAtFirstError: true
@@ -163,17 +171,6 @@ export class ResponseInterceptor implements NestInterceptor {
         if (errors.length) {
             throw new ResponseValidateException(errors);
         }
-
-        // Then run transforms with the group that matches the *outgoing* wire format:
-        //   - gRPC: `__sendData` so `@AnyType` JSON.stringify's array/object values into
-        //     proto `string` fields (otherwise protobuf coerces via `String([...])`
-        //     and the receiver sees `"[object Object],[object Object]"`).
-        //   - HTTP: no group — values pass through and Express/Nest JSON-serializes
-        //     the whole response.
-        const isGrpc = grpcMetadataClass && context.switchToRpc().getContext() instanceof grpcMetadataClass;
-        const groups = isGrpc ? ['__sendData', '__grpc'] : [];
-        applyTransforms(data, responseMetadata.responseClass, { groups });
-
         return data;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hodfords/nestjs-response",
-    "version": "11.1.4",
+    "version": "11.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hodfords/nestjs-response",
-            "version": "11.1.4",
+            "version": "11.1.5",
             "license": "UNLICENSED",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hodfords/nestjs-response",
-    "version": "11.1.4",
+    "version": "11.1.5",
     "description": "Standardizes and validates API responses in NestJS for consistent and reliable communication",
     "author": "",
     "license": "UNLICENSED",


### PR DESCRIPTION
## Summary

Replaces the two-step `validate then transform` flow PR #35 introduced with a single `applyTransforms` walk that runs `__getData` (always) plus `__sendData`/`__grpc` (on the gRPC path) before validation. Pairs with [`nestjs-grpc-helper#52`](https://github.com/hodfords-solutions/nestjs-grpc-helper/pull/52), which folds `@AnyType()`'s two phases into a single transform fn with a null guard.

## Why

PR #35 was opened to fix a gRPC-outgoing case where `@AnyType()`'s `__sendData` ran *before* validation and turned nullable `null` into the string `"null"`, breaking `@ValidateNested` + `@IsOptional`. PR #35's workaround was to reorder: validate *first*, then transform. That fixed the gRPC nullable case but reintroduced a regression on the HTTP path: polymorphic `@Transform({ toClassOnly: true })` discriminators (e.g. `@BlockDiscriminator`) no longer ran before `@ValidateNested`, and class-validator threw `"an unknown value was passed to the validate function"` on every plain array element.

Splitting the responsibilities across packages resolves both regressions structurally:

- `nestjs-grpc-helper@>=11.3.7` (the paired PR) fixes the *cause* of PR #35's bug — `@AnyType()`'s `__sendData` now skips `null`/`undefined`, so it can run before validation without corrupting nullable fields.
- This PR collapses `handleSingleResponse` back to a single transform call + validate, the same shape as the original 11.0.x flow, but with the always-on `__getData` group so JSONB-string columns get parsed before `@ValidateNested` iterates them on both HTTP and gRPC.

## The new flow

```ts
private handleSingleResponse(context, responseMetadata, data): object {
    if (NativeClassResponseNamesConstant.includes(responseMetadata.responseClass.name)) {
        return this.handleNativeValueResponse(responseMetadata, data);
    }

    const isGrpc = grpcMetadataClass && context.switchToRpc().getContext() instanceof grpcMetadataClass;
    const groups = isGrpc ? ['__getData', '__sendData', '__grpc'] : ['__getData'];
    applyTransforms(data, responseMetadata.responseClass, { groups });

    const errors = validatePlainSync(data, responseMetadata.responseClass, {
        whitelist: true,
        stopAtFirstError: true
    });
    if (errors.length) {
        throw new ResponseValidateException(errors);
    }
    return data;
}
```

One `applyTransforms` walk + one `validatePlainSync` on both paths.

## Trade-off — null wire round-trip

The null guard in the paired `@AnyType()` means `null` no longer survives the gRPC wire as `"null"` → `null`:

| Server has | Old (`null` → `"null"`) | New (null guard) |
|---|---|---|
| `null` | wire `"null"` → receiver gets `null` | wire `""` (proto3 default for absent string) → receiver gets `""` |
| `[{a:1}]` | wire `'[{"a":1}]'` → `[{a:1}]` | wire `'[{"a":1}]'` → `[{a:1}]` |

Consumers that need to distinguish "no value" from "empty string" need to either drop nullable `@ValidateNested` from their `@AnyType()` fields, or switch to a structured proto type. For the existing employer-backend consumers (activity history details, comment/notification responses) this is acceptable — none of them branch on `null` vs `""` post-deserialization.

## Test plan

- [x] `npx jest lib/interceptors/response.interceptor.spec.ts` — 5/5 pass.
- [x] `npx jest` — full suite passes.
- [x] `npm run lint` — clean.
- [x] In employer-backend, with paired `nestjs-grpc-helper` 11.3.7 + this revert: `apps/document/src/document/tests/document-level-permissions.e2e-spec.ts` — 56/56 pass; `apps/activity/src/histories/tests/response-interceptor-grpc-regression.spec.ts` — 4/4 pass.

## Migration

Bump both packages together. Mismatches re-introduce the bugs PR #35 and #37 were chasing:

| You're on | You upgrade | What happens |
|---|---|---|
| nestjs-response 11.1.4 + grpc-helper < 11.3.7 | this PR only | `__sendData` runs against a no-null-guard `@AnyType()` → `null` → `"null"` → validation fails on nullable `@ValidateNested + @IsOptional` |
| nestjs-response 11.1.4 + grpc-helper < 11.3.7 | grpc-helper 11.3.7 only | `@AnyType()` skips null on its own walk, but nestjs-response still runs the post-validate `__sendData` pass (no-op against already-stringified values, fine) |
| nestjs-response 11.1.4 + grpc-helper < 11.3.7 | both | single-pass flow works as designed |